### PR TITLE
take audit log service name from environment, which is fed by mta

### DIFF
--- a/core-node/router/routes/auditLog.js
+++ b/core-node/router/routes/auditLog.js
@@ -9,7 +9,7 @@ module.exports = function() {
 	var xsenv = require('@sap/xsenv');
 	xsenv.loadEnv();
 	var credentials = xsenv.getServices({
-		auditlog: 'shine-auditlog'
+		auditlog: process.env.AUDITLOG_INSTANCE_NAME
 	}).auditlog;
 	var auditLog = require('@sap/audit-logging')(credentials);
 

--- a/core-node/router/routes/datagen.js
+++ b/core-node/router/routes/datagen.js
@@ -12,7 +12,7 @@ module.exports = function() {
 	var xsenv = require('@sap/xsenv');
 	xsenv.loadEnv();
 	var credentials = xsenv.getServices({
-		auditlog: 'shine-auditlog'
+		auditlog: process.env.AUDITLOG_INSTANCE_NAME
 	}).auditlog;
 	var auditLog = require('@sap/audit-logging')(credentials);
 	var app = express.Router();

--- a/mta.yaml
+++ b/mta.yaml
@@ -45,6 +45,8 @@ modules:
     requires:
       - name: shine-uaa
       - name: shine-auditlog
+        properties:
+          AUDITLOG_INSTANCE_NAME: ${service-name}
       - name: shine-container
       - name: shine-core-db
       - name: shine-scheduler


### PR DESCRIPTION
The way it is ow, is hard coded, which makes it hard to deploy in development environment, because it mandates that the name of the instance is shine-audit-log and cannot be developer-specific